### PR TITLE
Allowed the Postman Client to use the workbook scopes

### DIFF
--- a/identity/client-apps.yaml
+++ b/identity/client-apps.yaml
@@ -12,6 +12,8 @@ Resources:
       AllowedOAuthFlowsUserPoolClient: True
       AllowedOAuthScopes:
         - openid
+        - "app.focusmark.workbook/workbook.write"
+        - "app.focusmark.workbook/workbook.read"
       CallbackURLs:
         - !Sub "https://${TargetEnvironment}.identity.focusmark.app"
       ClientName: !Join [ "-", [ 'focusmark', !Ref TargetEnvironment, 'userpoolclient', 'identity' ]]


### PR DESCRIPTION
Added the required scopes for the Postman client to request an Access Token for interacting with the Workbook API.